### PR TITLE
Add slash for namespaces, add local dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The goal of this repo is to contain GraphQL custom scalar specifications.
 # Contributing to this repo
 
 This repository is managed by EasyCLA. Project participants must sign the free
-([GraphQL Specification Membership agreement](https://preview-spec-membership.graphql.org)
+[GraphQL Specification Membership agreement](https://preview-spec-membership.graphql.org)
 before making a contribution. You only need to do this one time, and it can be
 signed by
 [individual contributors](http://individual-spec-membership.graphql.org/) or
@@ -23,11 +23,13 @@ If you have issues, please email
 ## Local development setup
 
 Install dependencies with
+
 ```shell
 npm install
 ```
 
 Then build with
+
 ```shell
 npm run build
 ```

--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ You can find
 [detailed information here](https://github.com/graphql/graphql-wg/tree/main/membership).
 If you have issues, please email
 [operations@graphql.org](mailto:operations@graphql.org).
+
+## Local development setup
+
+Install dependencies with
+```shell
+npm install
+```
+
+Then build with
+```shell
+npm run build
+```
+
+Navigate to the `/public` folder to view the built files.

--- a/build.sh
+++ b/build.sh
@@ -55,12 +55,13 @@ HTML="<html>
 
 echo "building specs"
 for AUTHOR in scalars/contributed/*; do
+  mkdir public/"$(basename $AUTHOR)"
   for FILE in "$AUTHOR"/*; do
-    spec-md --githubSource "https://github.com/graphql/graphql-scalars/blame/main/" "$FILE" > public/"$(basename $AUTHOR)"-"$(basename $FILE)".html
+    spec-md --githubSource "https://github.com/graphql/graphql-scalars/blame/main/" "$FILE" > public/"$(basename $AUTHOR)"/"$(basename $FILE .md)".html
     HTML="$HTML
       <tr>
         <td>$(basename $AUTHOR)</td>
-        <td><a href=\"$(basename $AUTHOR)-$(basename $FILE).html\">$(basename ${FILE%.*})</a></td>
+        <td><a href=\"$(basename $AUTHOR)/$(basename $FILE .md).html\">$(basename ${FILE%.*})</a></td>
       </tr>"
     true
   done


### PR DESCRIPTION
Separate namespace with a slash as per discussion https://github.com/graphql/graphql-scalars/issues/1

Add npm commands for local development