### PR TITLE
Tidy wording and remove grammar formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@ Thanks for contributing to GraphQL Scalars.
 
 The goal of the GraphQL Scalars project is to provide a directory of GraphQL
 Custom Scalar specifications, contributed by the community. Contributed
-specifications will be hosted on a GraphQL Foundation owned domain
+specifications are hosted on a GraphQL Foundation owned domain
 [scalars.graphql.org](https://scalars.graphql.org), which can be referenced with
-the built-in `@specifiedBy` GraphQL directive.
+the built-in `@specifiedBy`
+[GraphQL directive](https://spec.graphql.org/draft/#sec--specifiedBy).
 
 GraphQL Custom Scalar specifications are language agnostic and thus can be used
 to document and standardize behavior across different languages.
-
-We will confirm the domain details soon. We are currently setting this up.
 
 Please ensure that you read the
 [Code of Conduct](https://graphql.org/codeofconduct/) before contributing to

--- a/scalars/contributed/andimarek/date-time.md
+++ b/scalars/contributed/andimarek/date-time.md
@@ -2,9 +2,9 @@
 
 # DateTime — GraphQL Custom Scalar
 
-Author: andimarek
+Author - andimarek
 
-Date: 2022-10-18
+Date - 2022-10-18
 
 This is a String-based Scalar.
 

--- a/scalars/template-string.md
+++ b/scalars/template-string.md
@@ -2,9 +2,9 @@
 
 # \<name\> — GraphQL Custom Scalar
 
-"Author:\<github user name\> "
+"Author - \<github user name\> "
 
-"Date: \<the date of the first publication in YYYY-MM-DD format\>"
+"Date - \<the date of the first publication in YYYY-MM-DD format\>"
 
 This template is meant to be copied and modified. This template is meant for
 Scalars which are based on the built-in String Scalar

--- a/scalars/template.md
+++ b/scalars/template.md
@@ -2,9 +2,9 @@
 
 # \<name\> — GraphQL Custom Scalar
 
-"Author:\<github user name\> "
+"Author - \<github user name\> "
 
-"Date: \<the date of the first publication in YYYY-MM-DD format\>"
+"Date - \<the date of the first publication in YYYY-MM-DD format\>"
 
 This template is meant to be copied and modified. This template is meant for
 Scalars which are _not_ based on the built-in String Scalar


### PR DESCRIPTION
Changed wording as URL has been confirmed

I noticed that the colon in `Author :` and `Date :` caused the lines to be misread as GraphQL grammar. Changed to a dash to remove the Index section appearing at the bottom of Andi's DateTime spec.