### PR TITLE
Update incorrect example

### DIFF
--- a/scalars/contributed/andimarek/date-time.md
+++ b/scalars/contributed/andimarek/date-time.md
@@ -87,7 +87,7 @@ These are invalid examples:
 | ---------------------------------- | ------------------------------------------------------------------ |
 | `2011-08-30T13:22:53.108-03`       | The minutes of the offset are missing.                             |
 | `2011-08-30T13:22:53.108912Z`      | Too many digits for fractions of a second. Exactly three expected. |
-| `2011-08-30T24:22:53Z`             | Fractions of a second are missing.                                 |
+| `2011-08-30T23:22:53Z`             | Fractions of a second are missing.                                 |
 | `2011-08-30T13:22:53.108`          | No offset provided.                                                |
 | `2011-08-30`                       | No time provided.                                                  |
 | `2011-08-30T13:22:53.108-00:00`    | Negative offset (`-00:00`) is not allowed                          |


### PR DESCRIPTION
From https://github.com/andimarek/graphql-scalars.com/issues/13, @cmeeren makes a good point that the example in this diff is incorrect because of both the lack of seconds and that it's an invalid hour.