### PR TITLE
Allow to contribute using GitHub organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ this project.
    [graphql-scalars GitHub repository](https://github.com/graphql/graphql-scalars/tree/main/scalars).
 
 2. Modify your selected template, and save it in the correct place
-   `scalars/contributed/<github-user-or-organisation-name>/<scalar-name>.md` in
+   `scalars/contributed/<github-user-or-organization-name>/<scalar-name>.md` in
    the
    [graphql-scalars GitHub repository](https://github.com/graphql/graphql-scalars/tree/main/scalars/contributed).
    The directory location is important, as this will form part of the reference


### PR DESCRIPTION
See https://github.com/graphql/graphql-scalars/pull/32#issuecomment-3588693180

I think it's OK to allow organization names. Users and Organizations share the same namespace in GitHub so there is no risk of clash. 

It also allows to acknowledge the work that some organizations put in the community.