### PR TITLE
Remove JSON references

### DIFF
--- a/scalars/template-string.md
+++ b/scalars/template-string.md
@@ -31,7 +31,8 @@ Provide positive and negative examples of String return values.
 
 # Input coercion
 
-Define which GraphQL string Literals or external string values are accepted as input.
+Define which GraphQL string Literals or external string values are accepted as
+input.
 
 Provide positive and negative examples.
 

--- a/scalars/template.md
+++ b/scalars/template.md
@@ -2,7 +2,7 @@
 
 # \<name\> — GraphQL Custom Scalar
 
-"Author - \<github user or organization  name\> "
+"Author - \<github user or organization name\> "
 
 "Date - \<the date of the first publication in YYYY-MM-DD format\>"
 


### PR DESCRIPTION
GraphQL is transport agnostic and can be used on other formats than JSON (cbor, etc..).

I replaced "JSON" with "external value", which is the closest IMO?

All in all, there is some ambiguity in the GraphQL spec itself (see also https://github.com/graphql/graphql-js/pull/3065). This is not perfect but I believe this is more correct than assuming JSON.