### PR TITLE
Update example in ChilliCream DateTime/LocalDateTime scalars

### DIFF
--- a/scalars/contributed/chillicream/date-time.md
+++ b/scalars/contributed/chillicream/date-time.md
@@ -153,7 +153,7 @@ Invalid input values:
 | ----------------------------------- | -------------------------------------- |
 | `"2023-12-24T15:30:00"`             | Missing time zone offset.              |
 | `"2023-12-24 15:30:00Z"`            | Space instead of `T` or `t` separator. |
-| `"2023-12-24T25:00:00Z"`            | Invalid hour (25).                     |
+| `"2023-12-24T24:00:00Z"`            | Invalid hour (24).                     |
 | `"2023-12-24T15:60:00Z"`            | Invalid minute (60).                   |
 | `"2023-02-30T15:30:00Z"`            | Invalid date (February 30th).          |
 | `"2023-12-24T15:30:00.1234567890Z"` | More than 9 fractional second digits.  |

--- a/scalars/contributed/chillicream/local-date-time.md
+++ b/scalars/contributed/chillicream/local-date-time.md
@@ -146,7 +146,7 @@ Invalid input values:
 | `"2023-12-24T15:30:00Z"`           | Contains time zone indicator `Z`.                |
 | `"2023-12-24T15:30:00+05:30"`      | Contains time zone offset.                       |
 | `"2023-12-24 15:30:00"`            | Invalid separator (space instead of `T` or `t`). |
-| `"2023-12-24T25:00:00"`            | Invalid hour (25).                               |
+| `"2023-12-24T24:00:00"`            | Invalid hour (24).                               |
 | `"2023-12-24T15:60:00"`            | Invalid minute (60).                             |
 | `"2023-02-30T15:30:00"`            | Invalid date (February 30th).                    |
 | `"2023-12-24T15:30:00.1234567890"` | More than 9 fractional second digits.            |


### PR DESCRIPTION
Consistency with result values above. Avoid potential confusion about input supporting `24`, which it doesn't with RFC 3339.